### PR TITLE
[Suggestion] Use statsd host modification

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,15 @@ FROM ruby:alpine
 MAINTAINER Darren Oakley <daz.oakley@gmail.com>
 
 RUN apk update && apk upgrade
-RUN apk add ruby-dev build-base
+RUN apk add ruby-dev build-base git
 RUN rm -rf /var/cache/apk/*
 
-RUN gem install mini_statsd --no-rdoc --no-ri
+RUN mkdir /app
+WORKDIR /app
+ADD . /app
+
+RUN gem install bundler --no-rdoc --no-ri
+RUN bundle install
 
 EXPOSE 8125
 CMD ["mini_statsd", "8125"]

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gem 'mini_statsd', git: 'https://github.com/samfrench/Mini-StatsD.git', branch: 'bind-for-docker'


### PR DESCRIPTION
This "fixes" the use of the mini_statsd Docker usage. The gem works locally, but not inside a Docker container. I looked at the gem, and it looks like it binds to localhost. I changed it to bind to "0.0.0.0" which means statsd should be listening on all IP addresses the Docker container uses.

> https://github.com/samfrench/Mini-StatsD/commit/db866a5b387fa86e0e75ece5c7429677a03ec8e6

When using this modified gem in Docker, I can see the calls in the terminal window as though I'm running the gem locally on my machine.

As the traffic for this is UDP, clients should fire and forget about sending traffic to the host and port. The ruby client we use doesn't error if we can't connect to the statsd endpoint. Whereas the go application we use errors (and still works, but is misleading).

1) We could get the gem modifications merged into the main gem if this suggestion seems the best approach.
2) We could keep this approach, or add the modified Gemfile to the Docker container so we don't fetch from GitHub or RubyGems, but don't think that gives us many benefits.
3) We could look at a different statsd server (application or whatever it is called) to replace the one we are currently using.
4) Maybe there is something we could do with Docker, to allow localhost to bind to an IP through the routing table, by adding something to the Dockerfile.
5) We could use a different statsd client in go but this would be hard to do at the moment, due to understanding the code. Also this would just hide the issue. 
